### PR TITLE
Fix PowerShell launch script braces

### DIFF
--- a/launch.ps1
+++ b/launch.ps1
@@ -5,19 +5,27 @@ Set-Location $CURRENT_DIR
 Write-Host "=== Gif Studio Portable Launch (Final Fixed) ==="
 
 # Ensure logs directory and rotating log
-if (!(Test-Path "logs")) { New-Item -ItemType Directory -Path "logs" | Out-Null }
+if (!(Test-Path "logs")) {
+    New-Item -ItemType Directory -Path "logs" | Out-Null
+}
 $dateTag = Get-Date -Format "yyyy-MM-dd"
 $logFile = "logs/launch-$dateTag.log"
 Start-Transcript -Path $logFile -Append
 
 # Ensure config directory
-if (!(Test-Path "config")) { New-Item -ItemType Directory -Path "config" | Out-Null }
+if (!(Test-Path "config")) {
+    New-Item -ItemType Directory -Path "config" | Out-Null
+}
 
 # Load last port
 $lastPortFile = "config/lastport.txt"
 $port = 5173
 if (Test-Path $lastPortFile) {
-    try { $port = Get-Content $lastPortFile | Select-Object -First 1 } catch { $port = 5173 }
+    try {
+        $port = Get-Content $lastPortFile | Select-Object -First 1
+    } catch {
+        $port = 5173
+    }
 }
 
 # Node.js portable location
@@ -59,7 +67,9 @@ if (!(Test-Path "node_modules")) {
         & "$npmCmd" install | Tee-Object -FilePath "logs/install.log"
     } catch {
         Write-Host "⚠ npm install failed, retrying clean..."
-        if (Test-Path "node_modules") { Remove-Item -Recurse -Force "node_modules" }
+        if (Test-Path "node_modules") {
+            Remove-Item -Recurse -Force "node_modules"
+        }
         & "$npmCmd" install | Tee-Object -FilePath "logs/install.log"
     }
 }
@@ -68,8 +78,11 @@ function Wait-ForServer($tryPort) {
     for ($i = 0; $i -lt 40; $i++) {
         try {
             $res = curl.exe -s "http://localhost:$tryPort/"
-            if ($LASTEXITCODE -eq 0) { return $true }
-        } catch {}
+            if ($LASTEXITCODE -eq 0) {
+                return $true
+            }
+        } catch {
+        }
         Start-Sleep -Seconds 1
     }
     return $false
@@ -85,17 +98,22 @@ function Start-App($tryPort) {
         return $true
     } else {
         Write-Host "✖ Server failed to start on port $tryPort"
-        if ($process -and !$process.HasExited) { $process | Stop-Process -Force }
+        if ($process -and !$process.HasExited) {
+            $process | Stop-Process -Force
+        }
         return $false
     }
-} # <-- correctly closed here
+}
 
 # Try up to 10 ports
 $maxTries = 10
 $ok = $false
 for ($i = 0; $i -lt $maxTries; $i++) {
     $tryPort = [int]$port + $i
-    if (Start-App $tryPort) { $ok = $true; break }
+    if (Start-App $tryPort) {
+        $ok = $true
+        break
+    }
 }
 
 if (-not $ok) {


### PR DESCRIPTION
## Summary
- rewrite launch.ps1 to ensure all statement blocks and functions close cleanly
- keep existing launch logic while simplifying formatting for PowerShell parser compatibility

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d01e90de4c832d9176220b7ea91656