### PR TITLE
Improve navigation accessibility and responsive layout

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -49,17 +49,29 @@ function AppShell() {
         <div className="version">Studio Core v2.0</div>
       </header>
       <div className="app-body">
-        <nav className="side-nav">
-          {NAVIGATION.map((item) => (
-            <button
-              key={item.key}
-              className={item.key === activeView ? 'active' : ''}
-              onClick={() => setActiveView(item.key)}
-            >
-              <span className="nav-label">{item.label}</span>
-              <span className="nav-description">{item.description}</span>
-            </button>
-          ))}
+        <nav className="side-nav" aria-label="Studio sections">
+          <ul className="side-nav__list">
+            {NAVIGATION.map((item) => {
+              const isActive = item.key === activeView;
+              const descriptionId = `nav-${item.key}-description`;
+              return (
+                <li key={item.key} className="side-nav__item">
+                  <button
+                    type="button"
+                    className={isActive ? 'active' : ''}
+                    aria-current={isActive ? 'page' : undefined}
+                    aria-describedby={descriptionId}
+                    onClick={() => setActiveView(item.key)}
+                  >
+                    <span className="nav-label">{item.label}</span>
+                    <span id={descriptionId} className="nav-description">
+                      {item.description}
+                    </span>
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
         </nav>
         <main className="workspace">
           <ViewRenderer active={activeView} />

--- a/src/components/studio/CharacterDesigner.tsx
+++ b/src/components/studio/CharacterDesigner.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
 import { useStudioStore, useActiveCharacter, useActiveFrame } from '../../store/studioStore';
 import { composeFrame, pixelIndex } from '../../utils/frame';
 
@@ -164,6 +164,7 @@ export function CharacterDesigner() {
   );
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const [isDrawing, setIsDrawing] = useState(false);
+  const canvasInstructionsId = useId();
 
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -238,9 +239,16 @@ export function CharacterDesigner() {
   return (
     <div className="designer">
       <div className="canvas-wrapper">
+        <p id={canvasInstructionsId} className="sr-only">
+          Pixel canvas for editing {character.name}. Drag to paint with the current brush color or toggle eyedrop mode to sample
+          colors. Use right-click on palette swatches to remove them.
+        </p>
         <canvas
           ref={canvasRef}
           className="pixel-canvas"
+          role="img"
+          aria-label={`${character.name} pixel canvas`}
+          aria-describedby={canvasInstructionsId}
           onPointerDown={(event) => {
             setIsDrawing(true);
             (event.target as HTMLCanvasElement).setPointerCapture(event.pointerId);
@@ -253,6 +261,9 @@ export function CharacterDesigner() {
           onPointerUp={(event) => {
             setIsDrawing(false);
             (event.target as HTMLCanvasElement).releasePointerCapture(event.pointerId);
+          }}
+          onPointerLeave={() => {
+            setIsDrawing(false);
           }}
         />
       </div>

--- a/src/styles.css
+++ b/src/styles.css
@@ -20,11 +20,22 @@ textarea, input {
   font: inherit;
 }
 
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .app-shell {
   display: flex;
   flex-direction: column;
-  height: 100vh;
-  max-height: 100vh;
+  min-height: 100vh;
 }
 
 .app-header {
@@ -70,6 +81,20 @@ textarea, input {
   background: linear-gradient(180deg, rgba(30, 41, 59, 0.8), rgba(15, 23, 42, 0.95));
 }
 
+.side-nav__list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.side-nav__item {
+  min-width: 0;
+  display: flex;
+}
+
 .side-nav button {
   text-align: left;
   border: 1px solid transparent;
@@ -78,6 +103,7 @@ textarea, input {
   background: rgba(30, 64, 175, 0.15);
   color: inherit;
   transition: border 120ms ease, transform 120ms ease;
+  width: 100%;
 }
 
 .side-nav button:hover {
@@ -128,6 +154,7 @@ textarea, input {
   background: radial-gradient(circle at center, rgba(15, 118, 110, 0.12), rgba(15, 23, 42, 0.9));
   border-radius: 20px;
   border: 1px solid rgba(148, 163, 184, 0.25);
+  overflow: auto;
 }
 
 .pixel-canvas {
@@ -135,6 +162,8 @@ textarea, input {
   border: 1px solid rgba(148, 163, 184, 0.35);
   border-radius: 12px;
   box-shadow: 0 20px 60px rgba(15, 23, 42, 0.6);
+  max-width: 100%;
+  height: auto;
 }
 
 .sidebars {
@@ -556,10 +585,35 @@ textarea, input {
 
   .side-nav {
     flex-direction: row;
+    align-items: stretch;
     overflow-x: auto;
+    border-right: none;
+    border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+  }
+
+  .side-nav__list {
+    flex-direction: row;
+    min-width: max-content;
+    gap: 8px;
+  }
+
+  .side-nav__item {
+    flex: 0 0 auto;
   }
 
   .designer {
     grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 720px) {
+  .preview-panel {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .preview-controls {
+    flex-direction: row;
+    flex-wrap: wrap;
   }
 }


### PR DESCRIPTION
## Summary
- wrap studio navigation in a semantic list and add ARIA metadata for the active view
- add screen-reader guidance and accessibility attributes to the pixel canvas
- tweak layout styles to better support small screens and ensure the canvas scales within the viewport

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d02c4fbb48832da9f98212f981d98c