### PR TITLE
Add build version manifest UI and update relaunch support

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,9 @@ import { AnimationStudio } from './components/studio/AnimationStudio';
 import { AIGeneratorPanel } from './components/studio/AIGeneratorPanel';
 import { AssetLibrary } from './components/studio/AssetLibrary';
 import { SettingsPanel } from './components/studio/SettingsPanel';
+import { VersionBadge } from './components/common/VersionBadge';
+import { useUpdateWatcher } from './hooks/useVersionInfo';
+import type { VersionManifest } from './hooks/useVersionInfo';
 
 import './styles.css';
 
@@ -35,9 +38,17 @@ function ViewRenderer({ active }: { active: ViewKey }) {
   }
 }
 
+function formatManifestLabel(manifest?: VersionManifest | null) {
+  if (!manifest) {
+    return 'New build available';
+  }
+  return `v${manifest.version}${manifest.gitHash ? ` (${manifest.gitHash})` : ''}`;
+}
+
 function AppShell() {
   const [activeView, setActiveView] = useState<ViewKey>('designer');
   const activeNav = useMemo(() => NAVIGATION.find((item) => item.key === activeView), [activeView]);
+  const { currentVersion, latestVersion, updateAvailable, relaunch } = useUpdateWatcher();
 
   return (
     <div className="app-shell">
@@ -46,8 +57,20 @@ function AppShell() {
           <h1>Pixel Persona Studio</h1>
           <p className="subtitle">Create normalized pixel characters, orchestrate animations and experiment with AI-driven variations.</p>
         </div>
-        <div className="version">Studio Core v2.0</div>
+        <VersionBadge version={currentVersion} />
       </header>
+      {updateAvailable && (
+        <div className="update-banner" role="status" aria-live="polite">
+          <div className="update-banner__details">
+            <span className="update-banner__title">Update available</span>
+            <span className="update-banner__version">{formatManifestLabel(latestVersion)}</span>
+            <span className="update-banner__current">Current: {formatManifestLabel(currentVersion)}</span>
+          </div>
+          <button type="button" className="update-banner__action" onClick={relaunch}>
+            Relaunch now
+          </button>
+        </div>
+      )}
       <div className="app-body">
         <nav className="side-nav" aria-label="Studio sections">
           <ul className="side-nav__list">

--- a/src/components/common/VersionBadge.tsx
+++ b/src/components/common/VersionBadge.tsx
@@ -1,0 +1,47 @@
+import React, { useMemo } from 'react';
+import type { VersionManifest } from '../../hooks/useVersionInfo';
+
+interface VersionBadgeProps {
+  version: VersionManifest;
+}
+
+function formatBuildTime(buildTime?: string) {
+  if (!buildTime) {
+    return undefined;
+  }
+
+  try {
+    const parsed = new Date(buildTime);
+    if (Number.isNaN(parsed.getTime())) {
+      return undefined;
+    }
+    return parsed.toLocaleString(undefined, {
+      dateStyle: 'medium',
+      timeStyle: 'short'
+    });
+  } catch (error) {
+    return undefined;
+  }
+}
+
+function formatLabel(version: VersionManifest) {
+  const hash = version.gitHash ? ` (${version.gitHash})` : '';
+  return `v${version.version}${hash}`;
+}
+
+export const VersionBadge: React.FC<VersionBadgeProps> = ({ version }) => {
+  const buildTimestamp = useMemo(() => formatBuildTime(version.buildTime), [version.buildTime]);
+  const title = useMemo(() => {
+    const buildLabel = buildTimestamp ? `Build time: ${buildTimestamp}` : undefined;
+    const hashLabel = version.gitHash ? `Commit: ${version.gitHash}` : undefined;
+    return [buildLabel, hashLabel].filter(Boolean).join('\n');
+  }, [buildTimestamp, version.gitHash]);
+
+  return (
+    <div className="version-badge" title={title || undefined} aria-label={`Application version ${formatLabel(version)}`}>
+      <span className="version-badge__label">Build</span>
+      <span className="version-badge__value">{formatLabel(version)}</span>
+      {buildTimestamp && <span className="version-badge__time">{buildTimestamp}</span>}
+    </div>
+  );
+};

--- a/src/hooks/useVersionInfo.ts
+++ b/src/hooks/useVersionInfo.ts
@@ -1,0 +1,132 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+type NullableString = string | null | undefined;
+
+export interface VersionManifest {
+  version: string;
+  gitHash?: string;
+  buildTime?: string;
+}
+
+const CURRENT_MANIFEST: VersionManifest = {
+  version: __APP_VERSION__,
+  gitHash: __APP_GIT_HASH__ || undefined,
+  buildTime: __APP_BUILD_TIME__ || undefined
+};
+
+const VERSION_ENDPOINT = '/version.json';
+
+function normalize(value: NullableString) {
+  return (value ?? '').trim();
+}
+
+function manifestsMatch(next: VersionManifest | null | undefined) {
+  if (!next) {
+    return false;
+  }
+
+  return (
+    normalize(next.version) === normalize(CURRENT_MANIFEST.version) &&
+    normalize(next.gitHash) === normalize(CURRENT_MANIFEST.gitHash)
+  );
+}
+
+async function requestLatestManifest(): Promise<VersionManifest | null> {
+  try {
+    const response = await fetch(`${VERSION_ENDPOINT}?ts=${Date.now()}`, {
+      cache: 'no-store'
+    });
+
+    if (!response.ok) {
+      return null;
+    }
+
+    const data = (await response.json()) as VersionManifest;
+    if (!data || typeof data.version !== 'string') {
+      return null;
+    }
+
+    return {
+      version: data.version,
+      gitHash: normalize(data.gitHash) || undefined,
+      buildTime: data.buildTime
+    };
+  } catch (error) {
+    console.warn('[version] Failed to check for updates', error);
+    return null;
+  }
+}
+
+export function useVersionInfo() {
+  return useMemo(() => CURRENT_MANIFEST, []);
+}
+
+export function useUpdateWatcher(intervalMs = 60_000) {
+  const [latestVersion, setLatestVersion] = useState<VersionManifest | null>(null);
+  const [isChecking, setIsChecking] = useState(false);
+
+  const checkForUpdates = useCallback(async () => {
+    if (isChecking) {
+      return latestVersion;
+    }
+
+    setIsChecking(true);
+    const manifest = await requestLatestManifest();
+    setIsChecking(false);
+
+    if (manifest && !manifestsMatch(manifest)) {
+      setLatestVersion(manifest);
+    }
+
+    return manifest;
+  }, [isChecking, latestVersion]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const tick = async () => {
+      const manifest = await checkForUpdates();
+      if (!cancelled && manifest && manifestsMatch(manifest)) {
+        setLatestVersion(null);
+      }
+    };
+
+    if (typeof window !== 'undefined') {
+      tick();
+      const intervalId = window.setInterval(tick, intervalMs);
+      const onVisibilityChange = () => {
+        if (document.visibilityState === 'visible') {
+          tick();
+        }
+      };
+      document.addEventListener('visibilitychange', onVisibilityChange);
+
+      return () => {
+        cancelled = true;
+        window.clearInterval(intervalId);
+        document.removeEventListener('visibilitychange', onVisibilityChange);
+      };
+    }
+
+    return () => {
+      cancelled = true;
+    };
+  }, [checkForUpdates, intervalMs]);
+
+  const relaunch = useCallback(() => {
+    if (typeof window !== 'undefined') {
+      window.location.reload();
+    }
+  }, []);
+
+  const updateAvailable = useMemo(() => latestVersion !== null, [latestVersion]);
+
+  return {
+    currentVersion: CURRENT_MANIFEST,
+    latestVersion,
+    updateAvailable,
+    isChecking,
+    checkForUpdates,
+    relaunch
+  };
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -60,9 +60,85 @@ textarea, input {
   line-height: 1.5;
 }
 
-.version {
-  color: #6366f1;
+.version-badge {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 4px;
+  padding: 10px 14px;
+  border-radius: 12px;
+  background: rgba(79, 70, 229, 0.12);
+  border: 1px solid rgba(99, 102, 241, 0.35);
+  color: #c7d2fe;
   font-weight: 600;
+  box-shadow: inset 0 0 0 1px rgba(79, 70, 229, 0.15);
+}
+
+.version-badge__label {
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #818cf8;
+}
+
+.version-badge__value {
+  font-size: 16px;
+}
+
+.version-badge__time {
+  font-size: 11px;
+  color: #a5b4fc;
+}
+
+.update-banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 12px 24px;
+  background: linear-gradient(90deg, rgba(34, 197, 94, 0.2), rgba(59, 130, 246, 0.18));
+  border-bottom: 1px solid rgba(148, 163, 184, 0.3);
+}
+
+.update-banner__details {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.update-banner__title {
+  font-size: 13px;
+  font-weight: 700;
+  color: #bbf7d0;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.update-banner__version {
+  font-size: 14px;
+  color: #e0f2fe;
+}
+
+.update-banner__current {
+  font-size: 12px;
+  color: #bfdbfe;
+  opacity: 0.9;
+}
+
+.update-banner__action {
+  background: rgba(59, 130, 246, 0.85);
+  color: #0f172a;
+  font-weight: 600;
+  border: none;
+  padding: 10px 18px;
+  border-radius: 9999px;
+  box-shadow: 0 8px 20px rgba(59, 130, 246, 0.25);
+  transition: transform 120ms ease, box-shadow 120ms ease;
+}
+
+.update-banner__action:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(59, 130, 246, 0.35);
 }
 
 .app-body {

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -1,0 +1,11 @@
+declare const __APP_VERSION__: string;
+declare const __APP_GIT_HASH__: string;
+declare const __APP_BUILD_TIME__: string;
+
+declare global {
+  interface Window {
+    __APP_VERSION__?: string;
+  }
+}
+
+export {};

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,49 @@
-import { defineConfig } from 'vite';
+import { defineConfig, type Plugin } from 'vite';
 import react from '@vitejs/plugin-react';
+import { execSync } from 'node:child_process';
+import { version as appVersion } from './package.json';
+
+function resolveGitHash() {
+  try {
+    return execSync('git rev-parse --short HEAD').toString().trim();
+  } catch (error) {
+    return undefined;
+  }
+}
+
+const buildManifest = {
+  version: appVersion,
+  gitHash: resolveGitHash(),
+  buildTime: new Date().toISOString()
+};
+
+const versionManifestPlugin: Plugin = {
+  name: 'studio-version-manifest',
+  configureServer(server) {
+    server.middlewares.use((req, res, next) => {
+      if (req.url && req.url.startsWith('/version.json')) {
+        res.setHeader('Content-Type', 'application/json');
+        res.end(JSON.stringify(buildManifest));
+        return;
+      }
+      next();
+    });
+  },
+  generateBundle() {
+    this.emitFile({
+      type: 'asset',
+      fileName: 'version.json',
+      source: JSON.stringify(buildManifest, null, 2)
+    });
+  }
+};
 
 export default defineConfig({
-  plugins: [react()],
-  server: { port: 5173, strictPort: false }
+  plugins: [react(), versionManifestPlugin],
+  server: { port: 5173, strictPort: false },
+  define: {
+    __APP_VERSION__: JSON.stringify(buildManifest.version),
+    __APP_GIT_HASH__: JSON.stringify(buildManifest.gitHash ?? ''),
+    __APP_BUILD_TIME__: JSON.stringify(buildManifest.buildTime)
+  }
 });


### PR DESCRIPTION
## Summary
- expose git commit, package version, and build timestamp through a Vite build manifest
- render the current build metadata in the studio header and surface update availability inside the app
- add an update watcher hook plus styling that lets users relaunch the app when a newer build is detected

## Testing
- npm run build
- npm run test:gif
- npm run test:ai

------
https://chatgpt.com/codex/tasks/task_e_68d02ef8819c832dad429ebcbeaf9264