### PR TITLE
Fix Stable Diffusion default constant import

### DIFF
--- a/src/store/studioStore.tsx
+++ b/src/store/studioStore.tsx
@@ -1,6 +1,18 @@
 import React, { createContext, useContext, useEffect, useReducer } from 'react';
 import { createBlankAnimationFrame, createDerivedFrame, createId, createNormalizedCharacter } from '../utils/characterTemplate';
 import { blankPixels } from '../utils/frame';
+import { DEFAULT_STABLE_DIFFUSION_MODEL_ID } from '../services/stableDiffusionModelCatalog';
+import type {
+  BrushMode,
+  CharacterModel,
+  Frame,
+  Layer,
+  MirrorMode,
+  OnionSkinSettings,
+  PixelColor,
+  StudioSettings,
+  StudioState,
+} from '../types';
 
 export const STORAGE_KEY = 'pixel-persona-studio-state-v1';
 


### PR DESCRIPTION
## Summary
- import the missing DEFAULT_STABLE_DIFFUSION_MODEL_ID constant into the studio store to resolve the runtime ReferenceError that blanked the UI
- explicitly import the store type definitions from the shared types module for clarity and to satisfy TypeScript

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d033d54b94832daaa0f458adf37f45