### PR TITLE
Add manual folder picker for Stable Diffusion install path

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -515,6 +515,28 @@ textarea, input {
   resize: vertical;
 }
 
+.install-path {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.install-path button {
+  border-radius: 10px;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  background: rgba(30, 41, 59, 0.85);
+  color: inherit;
+  padding: 8px 12px;
+  min-height: 36px;
+  white-space: nowrap;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.install-path button:hover {
+  background: rgba(59, 130, 246, 0.25);
+  border-color: rgba(96, 165, 250, 0.6);
+}
+
 .brush-controls {
   display: flex;
   gap: 12px;


### PR DESCRIPTION
## Summary
- add a Browse action in the AI generator panel to let users pick a Stable Diffusion install directory
- capture the selected folder, update settings, and keep manual entry as a fallback when no path is resolved
- style the new picker controls so the input and Browse button align with existing fields

## Testing
- npm run test:ai

------
https://chatgpt.com/codex/tasks/task_e_68d03b5507e4832d80476641944f5732