### PR TITLE
Fix npm invocation quoting

### DIFF
--- a/launch.ps1
+++ b/launch.ps1
@@ -48,7 +48,9 @@ function Invoke-Npm {
     )
 
     $command = Get-CmdInvocationString -Executable $npmCmd -Arguments $Arguments
-    $cmdArgs = @("/d", "/s", "/c", $command)
+    # Wrap the entire command so cmd.exe handles paths that contain spaces.
+    $wrappedCommand = '"' + $command + '"'
+    $cmdArgs = @("/d", "/s", "/c", $wrappedCommand)
 
     if ($LogPath) {
         & $cmdExe $cmdArgs | Tee-Object -FilePath $LogPath
@@ -67,7 +69,9 @@ function Start-NpmProcess {
     )
 
     $command = Get-CmdInvocationString -Executable $npmCmd -Arguments $Arguments
-    $cmdArgs = @("/d", "/s", "/c", $command)
+    # Wrap the entire command so cmd.exe handles paths that contain spaces.
+    $wrappedCommand = '"' + $command + '"'
+    $cmdArgs = @("/d", "/s", "/c", $wrappedCommand)
 
     return Start-Process -FilePath $cmdExe -ArgumentList $cmdArgs -WorkingDirectory $CURRENT_DIR -PassThru -NoNewWindow
 }


### PR DESCRIPTION
## Summary
- wrap npm command strings passed to cmd.exe so npm runs cleanly when the project path includes spaces

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d03e4b50e8832d939f43b620e903e4