### PR TITLE
Fix GIF encoder output retrieval

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -41,8 +41,9 @@ function encodeTestFrames(): Uint8Array {
     });
   });
 
-  const buffer = encoder.finish();
-  return new Uint8Array(buffer);
+  encoder.finish();
+  const bytes = encoder.bytesView();
+  return new Uint8Array(bytes);
 }
 
 function createGradientFrame(startHex: string, endHex: string): Uint8ClampedArray {


### PR DESCRIPTION
## Summary
- finalize GIF encoding by calling `finish()` before reading bytes
- copy the encoder stream bytes to ensure the generated GIF includes header and trailer

## Testing
- npm run test:gif

------
https://chatgpt.com/codex/tasks/task_e_68d0453ae2e0832d8f437f167bee406b