### PR TITLE
Normalize Stable Diffusion path joins for Windows compatibility

### DIFF
--- a/src/services/aiService.ts
+++ b/src/services/aiService.ts
@@ -19,13 +19,31 @@ type SetupOptions = {
 
 let stableDiffusionState: StableDiffusionState | null = null;
 
+function normalizeSegment(segment: string, separator: '/' | '\\'): string {
+  if (separator === '\\') {
+    return segment.replace(/\//g, '\\');
+  }
+
+  return segment.replace(/[\\]+/g, '/');
+}
+
 function joinPaths(base: string, suffix: string): string {
   const trimmedBase = base.replace(/[\\/]+$/, '');
   const trimmedSuffix = suffix.replace(/^[\\/]+/, '');
-  if (!trimmedSuffix) {
-    return trimmedBase;
+
+  if (!trimmedBase) {
+    return trimmedSuffix;
   }
-  return `${trimmedBase}/${trimmedSuffix}`;
+
+  const baseUsesBackslash = trimmedBase.includes('\\') && !trimmedBase.includes('/');
+  const separator: '/' | '\\' = baseUsesBackslash ? '\\' : '/';
+
+  if (!trimmedSuffix) {
+    return normalizeSegment(trimmedBase, separator);
+  }
+
+  const normalizedSuffix = normalizeSegment(trimmedSuffix, separator);
+  return `${normalizeSegment(trimmedBase, separator)}${separator}${normalizedSuffix}`;
 }
 
 function resolveHomeDirectory(): string | undefined {


### PR DESCRIPTION
## Summary
- normalize Stable Diffusion path joins to respect platform-specific separators
- ensure suffix segments adopt the chosen separator to avoid mixed slashes

## Testing
- npm run build
- npm run test:ai
- npm run test:gif

------
https://chatgpt.com/codex/tasks/task_e_68d04c6cbec0832db40549aee0fec66f