### PR TITLE
Fix GIF loop flag handling

### DIFF
--- a/src/services/gif/makeGif.ts
+++ b/src/services/gif/makeGif.ts
@@ -25,7 +25,7 @@ export function makeGif(frames: GifFrame[], options: GifOptions): Uint8Array {
   frames.forEach(assertFrame);
 
   const encoder = GIFEncoder();
-  const repeat = options.loop ? 0 : 1;
+  const repeat = options.loop ? 0 : -1;
 
   frames.forEach((frame) => {
     const palette = quantize(frame.rgba, 256);

--- a/tests/gif.spec.ts
+++ b/tests/gif.spec.ts
@@ -23,4 +23,11 @@ describe('makeGif', () => {
     expect(['GIF87a', 'GIF89a']).toContain(header);
     expect(bytes.at(-1)).toBe(0x3b);
   });
+
+  it('omits the Netscape loop extension when looping is disabled', () => {
+    const frames = [createSolidFrame([0, 255, 0]), createSolidFrame([0, 0, 0])];
+    const bytes = makeGif(frames, { loop: false });
+    const ascii = String.fromCharCode(...bytes);
+    expect(ascii).not.toContain('NETSCAPE2.0');
+  });
 });


### PR DESCRIPTION
## Summary
- ensure GIFs built with loop disabled skip the Netscape loop extension
- add a regression test proving the GIF encoder omits loop metadata when looping is off

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d08d35aa58832e83dfb48ebbe5afed