### PR TITLE
Handle zero-size frames in computeFit

### DIFF
--- a/src/lib/fit-image.test.ts
+++ b/src/lib/fit-image.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+
+import { computeFit } from './fit-image';
+
+describe('computeFit', () => {
+  it('stretches when mode is stretch', () => {
+    const box = computeFit(100, 50, 200, 100, 'stretch');
+    expect(box).toEqual({ dx: 0, dy: 0, dw: 200, dh: 100 });
+  });
+
+  it('centres contained image preserving aspect ratio', () => {
+    const box = computeFit(100, 50, 200, 200, 'contain');
+    expect(box).toEqual({ dx: 0, dy: 50, dw: 200, dh: 100 });
+  });
+
+  it('fills frame when covering', () => {
+    const box = computeFit(100, 50, 200, 200, 'cover');
+    expect(box).toEqual({ dx: -100, dy: 0, dw: 400, dh: 200 });
+  });
+
+  it('returns finite measurements when source dimensions are invalid', () => {
+    const box = computeFit(0, -10, 64, 48, 'contain');
+
+    expect(box).toEqual({ dx: 0, dy: 0, dw: 64, dh: 48 });
+    expect(Object.values(box).every((value) => Number.isFinite(value))).toBe(true);
+  });
+});

--- a/src/lib/fit-image.ts
+++ b/src/lib/fit-image.ts
@@ -14,6 +14,15 @@ export const computeFit = (
   dstHeight: number,
   mode: FitMode
 ): FitBox => {
+  if (srcWidth <= 0 || srcHeight <= 0) {
+    return {
+      dx: 0,
+      dy: 0,
+      dw: dstWidth,
+      dh: dstHeight,
+    };
+  }
+
   if (mode === 'stretch') {
     return {
       dx: 0,


### PR DESCRIPTION
## Summary
- guard computeFit against zero or negative source dimensions so it returns finite draw bounds
- add regression tests covering stretch, contain, cover, and invalid dimension scenarios

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d0a1173350832e8efd40d9473ec3c4