### PR TITLE
Add sprite sheet importer

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -108,6 +108,21 @@ const StudioShell = () => {
     [addFrames, showToast]
   );
 
+  const handleSpriteFrames = useCallback(
+    (spriteFrames: FrameAsset[], meta?: { sourceName?: string }) => {
+      if (!spriteFrames.length) {
+        showToast('No frames were created from the sprite sheet.', 'error');
+        return;
+      }
+
+      addFrames(spriteFrames);
+      const baseMessage = `${spriteFrames.length} frame${spriteFrames.length === 1 ? '' : 's'} added`;
+      const details = meta?.sourceName ? ` from ${meta.sourceName}` : '';
+      showToast(`${baseMessage}${details}.`);
+    },
+    [addFrames, showToast]
+  );
+
   const handleMove = useCallback(
     (id: string, targetIndex: number) => {
       moveFrame(id, targetIndex);
@@ -173,7 +188,7 @@ const StudioShell = () => {
       </header>
       <main>
         <section className="column">
-          <FrameUploader onFiles={handleFiles} disabled={isExporting} />
+          <FrameUploader onFiles={handleFiles} onFrames={handleSpriteFrames} disabled={isExporting} />
           <TimelinePanel
             frames={frames}
             currentId={frames[currentIndex]?.id ?? null}

--- a/src/features/uploader/FrameUploader.tsx
+++ b/src/features/uploader/FrameUploader.tsx
@@ -1,7 +1,11 @@
 import { useCallback, useState, type ChangeEvent, type DragEvent } from 'react';
 
+import type { FrameAsset } from '../../types';
+import { SpriteSheetImporter } from './SpriteSheetImporter';
+
 interface FrameUploaderProps {
   onFiles: (files: File[]) => void;
+  onFrames?: (frames: FrameAsset[], meta?: { sourceName?: string }) => void;
   disabled?: boolean;
 }
 
@@ -23,8 +27,9 @@ const filterAcceptedFiles = (fileList: FileList | null) => {
   });
 };
 
-export const FrameUploader = ({ onFiles, disabled = false }: FrameUploaderProps) => {
+export const FrameUploader = ({ onFiles, onFrames, disabled = false }: FrameUploaderProps) => {
   const [isDragging, setIsDragging] = useState(false);
+  const [isSpriteSheetOpen, setSpriteSheetOpen] = useState(false);
 
   const handleFiles = useCallback(
     (files: FileList | null) => {
@@ -97,6 +102,26 @@ export const FrameUploader = ({ onFiles, disabled = false }: FrameUploaderProps)
           <span>or click to browse PNG, JPG, WEBP, or GIF files</span>
         </div>
       </label>
+      <div className="uploader-actions">
+        <button
+          type="button"
+          className="ghost"
+          onClick={() => setSpriteSheetOpen(true)}
+          disabled={disabled}
+        >
+          Import Sprite Sheet
+        </button>
+      </div>
+      {isSpriteSheetOpen ? (
+        <SpriteSheetImporter
+          disabled={disabled}
+          onCancel={() => setSpriteSheetOpen(false)}
+          onImport={(frames, meta) => {
+            onFrames?.(frames, meta);
+            setSpriteSheetOpen(false);
+          }}
+        />
+      ) : null}
     </div>
   );
 };

--- a/src/features/uploader/SpriteSheetImporter.tsx
+++ b/src/features/uploader/SpriteSheetImporter.tsx
@@ -1,0 +1,362 @@
+import { useCallback, useEffect, useMemo, useRef, useState, type ChangeEvent } from 'react';
+
+import type { FrameAsset } from '../../types';
+import { createId } from '../../lib/id';
+
+type ImportMeta = { sourceName?: string };
+
+interface SpriteSheetImporterProps {
+  disabled?: boolean;
+  onCancel: () => void;
+  onImport: (frames: FrameAsset[], meta?: ImportMeta) => void;
+}
+
+interface SheetData {
+  file: File;
+  image: HTMLImageElement;
+  url: string;
+  width: number;
+  height: number;
+}
+
+const toBlob = (canvas: HTMLCanvasElement): Promise<Blob> => {
+  return new Promise((resolve, reject) => {
+    canvas.toBlob((blob) => {
+      if (!blob) {
+        reject(new Error('Unable to create frame from sprite sheet.'));
+        return;
+      }
+      resolve(blob);
+    }, 'image/png');
+  });
+};
+
+const getBaseName = (name: string) => {
+  const index = name.lastIndexOf('.');
+  if (index <= 0) {
+    return name;
+  }
+  return name.slice(0, index);
+};
+
+const sliceSpriteSheet = async (
+  sheet: SheetData,
+  frameWidth: number,
+  frameHeight: number,
+  startFrame: number,
+  endFrame: number,
+  columns: number
+): Promise<FrameAsset[]> => {
+  const canvas = document.createElement('canvas');
+  canvas.width = frameWidth;
+  canvas.height = frameHeight;
+  const context = canvas.getContext('2d');
+  if (!context) {
+    throw new Error('Canvas rendering is not supported in this browser.');
+  }
+
+  const frames: FrameAsset[] = [];
+  const baseName = getBaseName(sheet.file.name) || 'sprite';
+
+  for (let index = startFrame - 1; index < endFrame; index += 1) {
+    const column = index % columns;
+    const row = Math.floor(index / columns);
+    const sourceX = column * frameWidth;
+    const sourceY = row * frameHeight;
+
+    if (sourceX + frameWidth > sheet.width || sourceY + frameHeight > sheet.height) {
+      continue;
+    }
+
+    context.clearRect(0, 0, frameWidth, frameHeight);
+    context.drawImage(
+      sheet.image,
+      sourceX,
+      sourceY,
+      frameWidth,
+      frameHeight,
+      0,
+      0,
+      frameWidth,
+      frameHeight
+    );
+
+    const blob = await toBlob(canvas);
+    const fileName = `${baseName}-${String(index + 1).padStart(3, '0')}.png`;
+    const frameFile = new File([blob], fileName, { type: 'image/png' });
+    const url = URL.createObjectURL(blob);
+
+    frames.push({
+      id: createId(),
+      name: fileName,
+      url,
+      width: frameWidth,
+      height: frameHeight,
+      file: frameFile,
+    });
+  }
+
+  return frames;
+};
+
+export const SpriteSheetImporter = ({ disabled = false, onCancel, onImport }: SpriteSheetImporterProps) => {
+  const isMountedRef = useRef(true);
+  const [sheet, setSheet] = useState<SheetData | null>(null);
+  const [frameWidth, setFrameWidth] = useState(64);
+  const [frameHeight, setFrameHeight] = useState(64);
+  const [startFrame, setStartFrame] = useState(1);
+  const [endFrame, setEndFrame] = useState<number | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isProcessing, setIsProcessing] = useState(false);
+
+  useEffect(() => {
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!sheet) {
+      return;
+    }
+
+    const handleKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        onCancel();
+      }
+    };
+
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [sheet, onCancel]);
+
+  useEffect(() => {
+    return () => {
+      if (sheet) {
+        URL.revokeObjectURL(sheet.url);
+      }
+    };
+  }, [sheet]);
+
+  const columns = useMemo(() => {
+    if (!sheet || frameWidth <= 0) {
+      return 0;
+    }
+    return Math.floor(sheet.width / frameWidth);
+  }, [sheet, frameWidth]);
+
+  const rows = useMemo(() => {
+    if (!sheet || frameHeight <= 0) {
+      return 0;
+    }
+    return Math.floor(sheet.height / frameHeight);
+  }, [sheet, frameHeight]);
+
+  const maxFrames = useMemo(() => {
+    if (!columns || !rows) {
+      return 0;
+    }
+    return columns * rows;
+  }, [columns, rows]);
+
+  useEffect(() => {
+    if (!maxFrames) {
+      return;
+    }
+    if (startFrame < 1) {
+      setStartFrame(1);
+    }
+    if (endFrame === null || endFrame > maxFrames) {
+      setEndFrame(maxFrames);
+    }
+  }, [maxFrames, startFrame, endFrame]);
+
+  const handleFileChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      const nextFile = event.target.files?.[0];
+      if (!nextFile) {
+        return;
+      }
+
+      setError(null);
+      setSheet((current) => {
+        if (current) {
+          URL.revokeObjectURL(current.url);
+        }
+        return null;
+      });
+
+      const url = URL.createObjectURL(nextFile);
+      const image = new Image();
+
+      image.onload = () => {
+        if (!isMountedRef.current) {
+          URL.revokeObjectURL(url);
+          return;
+        }
+        setSheet({
+          file: nextFile,
+          image,
+          url,
+          width: image.naturalWidth,
+          height: image.naturalHeight,
+        });
+        setFrameWidth(image.naturalHeight || 64);
+        setFrameHeight(image.naturalHeight || 64);
+        setStartFrame(1);
+        setEndFrame(null);
+      };
+
+      image.onerror = () => {
+        URL.revokeObjectURL(url);
+        if (!isMountedRef.current) {
+          return;
+        }
+        setError('Unable to load the selected sprite sheet.');
+      };
+
+      image.src = url;
+    },
+    []
+  );
+
+  const handleImport = useCallback(async () => {
+    if (!sheet) {
+      setError('Select a sprite sheet image to continue.');
+      return;
+    }
+
+    if (!columns || !rows) {
+      setError('Frame dimensions do not fit within the sprite sheet.');
+      return;
+    }
+
+    const targetEnd = endFrame ?? maxFrames;
+    if (startFrame > targetEnd) {
+      setError('Start frame must be less than or equal to the end frame.');
+      return;
+    }
+
+    setIsProcessing(true);
+    setError(null);
+    try {
+      const frames = await sliceSpriteSheet(sheet, frameWidth, frameHeight, startFrame, targetEnd, columns);
+      if (!frames.length) {
+        setError('No frames could be created from the provided settings.');
+        return;
+      }
+      onImport(frames, { sourceName: sheet.file.name });
+    } catch (importError) {
+      const message = importError instanceof Error ? importError.message : 'Import failed.';
+      setError(message);
+    } finally {
+      setIsProcessing(false);
+    }
+  }, [columns, endFrame, frameHeight, frameWidth, maxFrames, onImport, rows, sheet, startFrame]);
+
+  return (
+    <div className="sheet-overlay" role="dialog" aria-modal="true">
+      <div className="sheet-modal">
+        <div className="sheet-header">
+          <h3>Import Sprite Sheet</h3>
+          <p>Slice a single sprite sheet into multiple frames and add them to your timeline.</p>
+        </div>
+        <label className="sheet-file" aria-disabled={disabled}>
+          <span>Sprite sheet image</span>
+          <input
+            type="file"
+            accept="image/png,image/jpeg,image/jpg,image/webp,image/gif"
+            onChange={handleFileChange}
+            disabled={disabled || isProcessing}
+          />
+        </label>
+        {sheet ? (
+          <div className="sheet-body">
+            <div className="sheet-preview" role="img" aria-label={`Sprite sheet preview (${sheet.width} by ${sheet.height})`}>
+              <img src={sheet.url} alt="Sprite sheet preview" />
+            </div>
+            <div className="sheet-form">
+              <div className="sheet-grid">
+                <label>
+                  <span>Frame width</span>
+                  <input
+                    type="number"
+                    min={1}
+                    value={frameWidth}
+                    onChange={(event) => setFrameWidth(Number(event.target.value))}
+                    disabled={isProcessing}
+                  />
+                </label>
+                <label>
+                  <span>Frame height</span>
+                  <input
+                    type="number"
+                    min={1}
+                    value={frameHeight}
+                    onChange={(event) => setFrameHeight(Number(event.target.value))}
+                    disabled={isProcessing}
+                  />
+                </label>
+                <label>
+                  <span>Start frame</span>
+                  <input
+                    type="number"
+                    min={1}
+                    max={maxFrames || undefined}
+                    value={startFrame}
+                    onChange={(event) => setStartFrame(Number(event.target.value))}
+                    disabled={isProcessing || !maxFrames}
+                  />
+                </label>
+                <label>
+                  <span>End frame</span>
+                  <input
+                    type="number"
+                    min={startFrame}
+                    max={maxFrames || undefined}
+                    value={endFrame ?? ''}
+                    onChange={(event) => {
+                      const value = event.target.value;
+                      setEndFrame(value ? Number(value) : null);
+                    }}
+                    placeholder={maxFrames ? String(maxFrames) : ''}
+                    disabled={isProcessing || !maxFrames}
+                  />
+                </label>
+              </div>
+              <dl className="sheet-summary">
+                <div>
+                  <dt>Columns</dt>
+                  <dd>{columns}</dd>
+                </div>
+                <div>
+                  <dt>Rows</dt>
+                  <dd>{rows}</dd>
+                </div>
+                <div>
+                  <dt>Total frames</dt>
+                  <dd>{maxFrames}</dd>
+                </div>
+              </dl>
+            </div>
+          </div>
+        ) : null}
+        {error ? <p className="sheet-error" role="alert">{error}</p> : null}
+        <div className="sheet-actions">
+          <button type="button" className="ghost" onClick={onCancel} disabled={isProcessing}>
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="primary-action"
+            onClick={handleImport}
+            disabled={disabled || isProcessing || !sheet}
+          >
+            Import frames
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/styles.css
+++ b/src/styles.css
@@ -178,6 +178,15 @@ main {
   cursor: not-allowed;
 }
 
+.uploader-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.uploader-actions .ghost {
+  align-self: flex-start;
+}
+
 .timeline {
   display: flex;
   flex-direction: column;
@@ -256,6 +265,161 @@ main {
 .timeline-controls {
   display: flex;
   gap: 8px;
+}
+
+.sheet-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(5, 8, 22, 0.7);
+  backdrop-filter: blur(6px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  z-index: 1000;
+}
+
+.sheet-modal {
+  width: min(720px, 100%);
+  max-height: min(640px, 100%);
+  background: rgba(15, 23, 42, 0.95);
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  border-radius: 24px;
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  box-shadow: 0 20px 60px rgba(15, 23, 42, 0.45);
+}
+
+.sheet-header h3 {
+  margin: 0;
+  font-size: 1.3rem;
+}
+
+.sheet-header p {
+  margin: 8px 0 0;
+  color: rgba(203, 213, 225, 0.75);
+}
+
+.sheet-file {
+  position: relative;
+  display: block;
+  padding: 16px;
+  border: 1px dashed rgba(148, 163, 184, 0.4);
+  border-radius: 14px;
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.sheet-file input {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  cursor: pointer;
+}
+
+.sheet-file[aria-disabled='true'] {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.sheet-body {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: minmax(0, 1fr);
+}
+
+@media (min-width: 768px) {
+  .sheet-body {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+.sheet-preview {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 12px;
+  background: rgba(30, 41, 59, 0.85);
+  border: 1px solid rgba(100, 116, 139, 0.35);
+  border-radius: 16px;
+  overflow: auto;
+  max-height: 320px;
+}
+
+.sheet-preview img {
+  width: 100%;
+  height: auto;
+  object-fit: contain;
+}
+
+.sheet-form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.sheet-grid {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.sheet-grid label {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 0.9rem;
+}
+
+.sheet-grid input {
+  padding: 8px 10px;
+  border-radius: 8px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.6);
+  color: inherit;
+}
+
+.sheet-summary {
+  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.sheet-summary div {
+  background: rgba(30, 41, 59, 0.6);
+  border: 1px solid rgba(100, 116, 139, 0.3);
+  border-radius: 12px;
+  padding: 10px;
+  text-align: center;
+}
+
+.sheet-summary dt {
+  margin: 0;
+  font-size: 0.8rem;
+  color: rgba(203, 213, 225, 0.7);
+}
+
+.sheet-summary dd {
+  margin: 4px 0 0;
+  font-weight: 600;
+  font-size: 1.05rem;
+}
+
+.sheet-error {
+  margin: 0;
+  padding: 12px 14px;
+  border-radius: 12px;
+  background: rgba(239, 68, 68, 0.18);
+  border: 1px solid rgba(239, 68, 68, 0.35);
+  color: #fecaca;
+}
+
+.sheet-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
 }
 
 button.ghost {


### PR DESCRIPTION
## Summary
- add a sprite sheet importer overlay that slices source images into frame assets before adding them to the studio
- extend the frame uploader to launch the importer and surface success messaging for newly generated frames
- style the importer experience with overlay, form, and summary details for sprite sheet slicing

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_b_68d0a2c3e220832e81600f52cf5c26e1