### PR TITLE
Add manual frame selection for sprite sheets

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -347,10 +347,50 @@ main {
   max-height: 320px;
 }
 
-.sheet-preview img {
+.sheet-preview-frame {
+  position: relative;
+  display: inline-block;
+}
+
+.sheet-preview-frame img {
+  display: block;
   width: 100%;
   height: auto;
   object-fit: contain;
+}
+
+.sheet-cell-grid {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  pointer-events: none;
+}
+
+.sheet-cell {
+  margin: 0;
+  padding: 0;
+  width: 100%;
+  height: 100%;
+  background: transparent;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  cursor: pointer;
+  pointer-events: auto;
+  transition: background 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.sheet-cell:hover {
+  border-color: rgba(148, 163, 184, 0.6);
+}
+
+.sheet-cell:focus-visible {
+  outline: 2px solid #38bdf8;
+  outline-offset: -2px;
+}
+
+.sheet-cell.is-active {
+  background: rgba(59, 130, 246, 0.3);
+  border-color: rgba(96, 165, 250, 0.9);
+  box-shadow: inset 0 0 0 1px rgba(37, 99, 235, 0.7);
 }
 
 .sheet-form {
@@ -383,7 +423,7 @@ main {
 .sheet-summary {
   margin: 0;
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
   gap: 12px;
 }
 
@@ -405,6 +445,18 @@ main {
   margin: 4px 0 0;
   font-weight: 600;
   font-size: 1.05rem;
+}
+
+.sheet-manual-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  font-size: 0.85rem;
+  color: rgba(203, 213, 225, 0.75);
+}
+
+.sheet-manual-actions .ghost {
+  align-self: flex-start;
 }
 
 .sheet-error {


### PR DESCRIPTION
## Summary
- add manual selection support in the sprite sheet importer, including validation for empty selections
- render a clickable grid overlay so users can toggle individual frames and clear manual choices when needed
- style the overlay and selection summary to surface the number of chosen frames

## Testing
- npm run lint
- npm run typecheck
- npm test
- npm run test:gif *(fails: Missing script "test:gif")*


------
https://chatgpt.com/codex/tasks/task_b_68d0ada95dc0832eb5f41a1444fd4e31