### PR TITLE
Fix sprite sheet importer width default

### DIFF
--- a/src/features/uploader/SpriteSheetImporter.tsx
+++ b/src/features/uploader/SpriteSheetImporter.tsx
@@ -391,7 +391,7 @@ export const SpriteSheetImporter = ({ disabled = false, onCancel, onImport }: Sp
           width: image.naturalWidth,
           height: image.naturalHeight,
         });
-        setFrameWidth(image.naturalHeight || 64);
+        setFrameWidth(image.naturalWidth || 64);
         setFrameHeight(image.naturalHeight || 64);
         setStartFrame(1);
         setEndFrame(null);


### PR DESCRIPTION
## Summary
- initialize the sprite sheet importer width control from the sheet's natural width
- keep the height initialisation unchanged so the UI reflects the actual sheet dimensions

## Testing
- npm run lint
- npm run typecheck
- npm test -- --run
- npm run test:gif *(fails: Missing script: "test:gif")*

------
https://chatgpt.com/codex/tasks/task_b_68d0b50e1b50832e911dc37a910f133a