### PR TITLE
Add sprite sheet export via template

### DIFF
--- a/src/features/export/SpriteSheetExportPanel.tsx
+++ b/src/features/export/SpriteSheetExportPanel.tsx
@@ -1,0 +1,255 @@
+import { useCallback, useMemo, useState, type ChangeEvent } from 'react';
+
+import type { FrameAsset } from '../../types';
+import {
+  computeSpriteSheetSize,
+  createSpriteSheet,
+  loadSpriteTemplateFile,
+  type LoadedSpriteTemplate,
+} from '../../lib/sprite-template';
+
+interface SpriteSheetExportPanelProps {
+  frames: FrameAsset[];
+  disabled?: boolean;
+  onToast: (message: string, tone?: 'success' | 'error') => void;
+}
+
+export const SpriteSheetExportPanel = ({
+  frames,
+  disabled = false,
+  onToast,
+}: SpriteSheetExportPanelProps) => {
+  const [template, setTemplate] = useState<LoadedSpriteTemplate | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isProcessing, setIsProcessing] = useState(false);
+
+  const templateStats = useMemo(() => {
+    if (!template) {
+      return null;
+    }
+    return computeSpriteSheetSize(template);
+  }, [template]);
+
+  const capacityStatus = useMemo(() => {
+    if (!templateStats) {
+      return null;
+    }
+    const remaining = templateStats.capacity - frames.length;
+    if (frames.length === 0) {
+      return {
+        tone: 'info' as const,
+        message: 'Add frames to your timeline to populate this template.',
+        remaining,
+      };
+    }
+    if (remaining < 0) {
+      const overflow = Math.abs(remaining);
+      return {
+        tone: 'error' as const,
+        message: `Remove ${overflow} frame${overflow === 1 ? '' : 's'} or choose a larger template.`,
+        remaining,
+      };
+    }
+    if (remaining === 0) {
+      return {
+        tone: 'success' as const,
+        message: 'All template slots will be filled.',
+        remaining,
+      };
+    }
+    return {
+      tone: 'info' as const,
+      message: `${remaining} empty slot${remaining === 1 ? '' : 's'} will remain after export.`,
+      remaining,
+    };
+  }, [templateStats, frames.length]);
+
+  const handleTemplateChange = useCallback(
+    async (event: ChangeEvent<HTMLInputElement>) => {
+      const file = event.target.files?.[0];
+      if (!file) {
+        return;
+      }
+      setError(null);
+      try {
+        const loaded = await loadSpriteTemplateFile(file);
+        setTemplate(loaded);
+      } catch (templateError) {
+        const message =
+          templateError instanceof Error
+            ? templateError.message
+            : 'Unable to read the selected sprite template.';
+        setTemplate(null);
+        setError(message);
+        onToast(message, 'error');
+      } finally {
+        event.target.value = '';
+      }
+    },
+    [onToast]
+  );
+
+  const handleClearTemplate = useCallback(() => {
+    setTemplate(null);
+    setError(null);
+  }, []);
+
+  const canExport = useMemo(() => {
+    if (!template || !templateStats) {
+      return false;
+    }
+    if (frames.length === 0) {
+      return false;
+    }
+    if (capacityStatus && capacityStatus.tone === 'error') {
+      return false;
+    }
+    return true;
+  }, [template, templateStats, frames.length, capacityStatus]);
+
+  const handleExport = useCallback(async () => {
+    if (!template) {
+      setError('Upload a sprite template before creating a sprite sheet.');
+      return;
+    }
+
+    if (!frames.length) {
+      setError('Add frames to your timeline before creating a sprite sheet.');
+      return;
+    }
+
+    if (capacityStatus && capacityStatus.tone === 'error') {
+      setError(capacityStatus.message);
+      return;
+    }
+
+    setIsProcessing(true);
+    setError(null);
+    try {
+      const blob = await createSpriteSheet(frames, template);
+      const baseName =
+        template.name?.trim() || template.sourceName.replace(/\.[^./]+$/, '') || 'sprite-sheet';
+      const fileName = `${baseName}.png`;
+      const url = URL.createObjectURL(blob);
+      const anchor = document.createElement('a');
+      anchor.href = url;
+      anchor.download = fileName;
+      document.body.appendChild(anchor);
+      anchor.click();
+      anchor.remove();
+      URL.revokeObjectURL(url);
+      onToast('Sprite sheet export complete.');
+    } catch (exportError) {
+      const message =
+        exportError instanceof Error
+          ? exportError.message
+          : 'Unable to create sprite sheet. Please try again.';
+      setError(message);
+      onToast(message, 'error');
+    } finally {
+      setIsProcessing(false);
+    }
+  }, [template, frames, capacityStatus, onToast]);
+
+  const templateName = template?.name ?? template?.sourceName ?? 'Template';
+
+  return (
+    <div className="panel">
+      <div className="panel-header">
+        <h2>Sprite Sheet</h2>
+        <p>Upload a JSON template to assemble your frames into a sprite sheet image.</p>
+      </div>
+      <div className="sprite-export">
+        <label className="sprite-template-upload">
+          <span>Sprite template JSON</span>
+          <input
+            type="file"
+            accept="application/json"
+            onChange={handleTemplateChange}
+            disabled={disabled || isProcessing}
+            aria-disabled={disabled || isProcessing}
+          />
+        </label>
+        {template ? (
+          <>
+            <dl className="sprite-template-summary">
+              <div>
+                <dt>Template</dt>
+                <dd>{templateName}</dd>
+              </div>
+              <div>
+                <dt>Grid</dt>
+                <dd>
+                  {template.columns} × {template.rows}
+                </dd>
+              </div>
+              <div>
+                <dt>Frame size</dt>
+                <dd>
+                  {template.frameWidth} × {template.frameHeight}
+                </dd>
+              </div>
+              <div>
+                <dt>Canvas size</dt>
+                <dd>
+                  {templateStats?.width} × {templateStats?.height}
+                </dd>
+              </div>
+              <div>
+                <dt>Capacity</dt>
+                <dd>{templateStats?.capacity}</dd>
+              </div>
+              <div>
+                <dt>Frames in timeline</dt>
+                <dd>{frames.length}</dd>
+              </div>
+            </dl>
+            {capacityStatus ? (
+              <p className={`sprite-template-note${capacityStatus.tone === 'error' ? ' is-error' : ''}`}>
+                {capacityStatus.message}
+              </p>
+            ) : null}
+            <div className="sprite-template-actions">
+              <button
+                type="button"
+                className="ghost"
+                onClick={handleClearTemplate}
+                disabled={disabled || isProcessing}
+              >
+                Remove template
+              </button>
+              <button
+                type="button"
+                className="primary-action"
+                onClick={handleExport}
+                disabled={!canExport || disabled || isProcessing}
+              >
+                {isProcessing ? 'Creating sprite sheet…' : 'Create sprite sheet'}
+              </button>
+            </div>
+          </>
+        ) : (
+          <>
+            <p className="sprite-template-placeholder" role="status">
+              JSON must include frameWidth, frameHeight, columns, and rows. Optional keys: spacing,
+              margin, background, and fitMode.
+            </p>
+            <div className="sprite-template-actions">
+              <button type="button" className="ghost" onClick={handleClearTemplate} disabled>
+                Remove template
+              </button>
+              <button type="button" className="primary-action" disabled>
+                Create sprite sheet
+              </button>
+            </div>
+          </>
+        )}
+        {error ? (
+          <p className="sprite-template-error" role="alert">
+            {error}
+          </p>
+        ) : null}
+      </div>
+    </div>
+  );
+};

--- a/src/features/workspace/StudioWorkspace.tsx
+++ b/src/features/workspace/StudioWorkspace.tsx
@@ -7,6 +7,7 @@ import { useStudioActions } from '../studio/useStudioActions';
 import { TimelinePanel } from '../timeline/TimelinePanel';
 import { FrameUploader } from '../uploader/FrameUploader';
 import { Toast } from '../ui/Toast';
+import { SpriteSheetExportPanel } from '../export/SpriteSheetExportPanel';
 import { encodeGif } from '../../lib/gif-encoder';
 import { loadFrame, revokeFrame } from '../../lib/load-frame';
 import type { FrameAsset } from '../../types';
@@ -316,6 +317,11 @@ export const StudioWorkspace = () => {
             onSettingsChange={updateExportSettings}
             onExport={handleExport}
             isExporting={isExporting}
+          />
+          <SpriteSheetExportPanel
+            frames={frames}
+            disabled={isExporting}
+            onToast={showToast}
           />
         </section>
       </div>

--- a/src/lib/sprite-template.test.ts
+++ b/src/lib/sprite-template.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest';
+
+import type { SpriteTemplate } from './sprite-template';
+import {
+  computeSpriteSheetSize,
+  createSpriteSheet,
+  loadSpriteTemplateFile,
+} from './sprite-template';
+
+describe('sprite template helpers', () => {
+  it('loads and normalizes template JSON', async () => {
+    const file = new File(
+      [
+        JSON.stringify({
+          name: 'WalkCycle',
+          frameWidth: 64,
+          frameHeight: 48,
+          columns: 5,
+          rows: 3,
+          spacing: 2.4,
+          margin: 4.2,
+          background: '#111827',
+          fitMode: 'cover',
+        }),
+      ],
+      'walk-cycle.json',
+      { type: 'application/json' }
+    );
+
+    const template = await loadSpriteTemplateFile(file);
+
+    expect(template.name).toBe('WalkCycle');
+    expect(template.frameWidth).toBe(64);
+    expect(template.frameHeight).toBe(48);
+    expect(template.columns).toBe(5);
+    expect(template.rows).toBe(3);
+    expect(template.spacing).toBe(2);
+    expect(template.margin).toBe(4);
+    expect(template.background).toBe('#111827');
+    expect(template.fitMode).toBe('cover');
+    expect(template.sourceName).toBe('walk-cycle.json');
+  });
+
+  it('throws when required fields are missing', async () => {
+    const file = new File([JSON.stringify({ frameWidth: 32 })], 'invalid.json', {
+      type: 'application/json',
+    });
+
+    await expect(loadSpriteTemplateFile(file)).rejects.toThrow('frameHeight');
+  });
+
+  it('computes sprite sheet size from template', () => {
+    const template: SpriteTemplate = {
+      frameWidth: 32,
+      frameHeight: 32,
+      columns: 4,
+      rows: 2,
+      spacing: 1,
+      margin: 2,
+      background: '#000',
+      fitMode: 'contain',
+    };
+
+    const metrics = computeSpriteSheetSize(template);
+
+    expect(metrics.width).toBe(4 * 32 + 3 * 1 + 4); // columns * width + spacing gaps + margins
+    expect(metrics.height).toBe(2 * 32 + 1 * 1 + 4);
+    expect(metrics.capacity).toBe(8);
+  });
+
+  it('refuses to render when more frames are provided than template capacity', async () => {
+    const template: SpriteTemplate = {
+      frameWidth: 32,
+      frameHeight: 32,
+      columns: 2,
+      rows: 2,
+      spacing: 0,
+      margin: 0,
+      background: 'transparent',
+      fitMode: 'contain',
+    };
+
+    const stubFile = new File([], 'frame.png', { type: 'image/png' });
+    const frames = Array.from({ length: 5 }, (_, index) => ({
+      id: `frame-${index}`,
+      name: `Frame ${index}`,
+      url: '',
+      width: 32,
+      height: 32,
+      file: stubFile,
+    }));
+
+    await expect(createSpriteSheet(frames, template)).rejects.toThrow('fit 4 frame');
+  });
+
+  it('requires at least one frame before exporting', async () => {
+    const template: SpriteTemplate = {
+      frameWidth: 16,
+      frameHeight: 16,
+      columns: 1,
+      rows: 1,
+      spacing: 0,
+      margin: 0,
+      background: 'transparent',
+      fitMode: 'contain',
+    };
+
+    await expect(createSpriteSheet([], template)).rejects.toThrow('Add frames');
+  });
+});

--- a/src/lib/sprite-template.ts
+++ b/src/lib/sprite-template.ts
@@ -1,0 +1,253 @@
+import type { FitMode, FrameAsset } from '../types';
+import { computeFit } from './fit-image';
+
+export interface SpriteTemplate {
+  name?: string;
+  frameWidth: number;
+  frameHeight: number;
+  columns: number;
+  rows: number;
+  spacing: number;
+  margin: number;
+  background: string;
+  fitMode: FitMode;
+}
+
+export interface LoadedSpriteTemplate extends SpriteTemplate {
+  sourceName: string;
+}
+
+const getValue = (source: Record<string, unknown>, keys: string[]): unknown => {
+  for (const key of keys) {
+    if (key in source) {
+      return source[key];
+    }
+  }
+  return undefined;
+};
+
+const clampPositiveInteger = (value: unknown, key: string, max = 4096) => {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric) || numeric <= 0) {
+    throw new Error(`Template ${key} must be a positive number.`);
+  }
+  return Math.min(max, Math.round(numeric));
+};
+
+const clampCount = (value: unknown, key: string) => clampPositiveInteger(value, key, 512);
+
+const clampNonNegative = (value: unknown, key: string, max = 1024) => {
+  if (value === undefined) {
+    return 0;
+  }
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric) || numeric < 0) {
+    throw new Error(`Template ${key} must be zero or greater.`);
+  }
+  return Math.min(max, Math.round(numeric));
+};
+
+const parseFitMode = (value: unknown, fallback: FitMode): FitMode => {
+  if (typeof value === 'string') {
+    const normalized = value.toLowerCase();
+    if (normalized === 'contain' || normalized === 'cover' || normalized === 'stretch') {
+      return normalized;
+    }
+  }
+  return fallback;
+};
+
+const parseBackground = (value: unknown) => {
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (trimmed) {
+      return trimmed;
+    }
+  }
+  return 'transparent';
+};
+
+const parseName = (value: unknown) => {
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed || undefined;
+  }
+  return undefined;
+};
+
+export const parseSpriteTemplate = (input: unknown): SpriteTemplate => {
+  if (!input || typeof input !== 'object') {
+    throw new Error('Sprite template must be a JSON object.');
+  }
+
+  const source = input as Record<string, unknown>;
+
+  const frameWidthValue = getValue(source, ['frameWidth', 'tileWidth', 'cellWidth']);
+  const frameHeightValue = getValue(source, ['frameHeight', 'tileHeight', 'cellHeight']);
+  const columnsValue = getValue(source, ['columns', 'cols']);
+  const rowsValue = getValue(source, ['rows']);
+
+  if (frameWidthValue === undefined) {
+    throw new Error('Template is missing a frameWidth value.');
+  }
+  if (frameHeightValue === undefined) {
+    throw new Error('Template is missing a frameHeight value.');
+  }
+  if (columnsValue === undefined) {
+    throw new Error('Template is missing a columns value.');
+  }
+  if (rowsValue === undefined) {
+    throw new Error('Template is missing a rows value.');
+  }
+
+  const frameWidth = clampPositiveInteger(frameWidthValue, 'frameWidth');
+  const frameHeight = clampPositiveInteger(frameHeightValue, 'frameHeight');
+  const columns = clampCount(columnsValue, 'columns');
+  const rows = clampCount(rowsValue, 'rows');
+
+  const spacingValue = getValue(source, ['spacing', 'gap', 'gutter']);
+  const marginValue = getValue(source, ['margin', 'padding']);
+  const backgroundValue = getValue(source, ['background', 'backgroundColor']);
+  const fitModeValue = getValue(source, ['fitMode', 'fit']);
+  const nameValue = getValue(source, ['name', 'template', 'id']);
+
+  return {
+    name: parseName(nameValue),
+    frameWidth,
+    frameHeight,
+    columns,
+    rows,
+    spacing: clampNonNegative(spacingValue, 'spacing'),
+    margin: clampNonNegative(marginValue, 'margin'),
+    background: parseBackground(backgroundValue),
+    fitMode: parseFitMode(fitModeValue, 'contain'),
+  };
+};
+
+export const loadSpriteTemplateFile = async (file: File): Promise<LoadedSpriteTemplate> => {
+  const text = await file.text();
+  let data: unknown;
+  try {
+    data = JSON.parse(text);
+  } catch {
+    throw new Error('Template file must contain valid JSON.');
+  }
+
+  const template = parseSpriteTemplate(data);
+  const baseName = file.name.replace(/\.[^./]+$/, '');
+
+  const resolvedName = template.name ?? (baseName ? baseName : undefined);
+
+  return {
+    ...template,
+    name: resolvedName,
+    sourceName: file.name,
+  };
+};
+
+export const computeSpriteSheetSize = (template: SpriteTemplate) => {
+  const width =
+    template.columns * template.frameWidth +
+    template.spacing * Math.max(0, template.columns - 1) +
+    template.margin * 2;
+  const height =
+    template.rows * template.frameHeight +
+    template.spacing * Math.max(0, template.rows - 1) +
+    template.margin * 2;
+  const capacity = template.columns * template.rows;
+
+  return {
+    width: Math.max(1, Math.round(width)),
+    height: Math.max(1, Math.round(height)),
+    capacity,
+  };
+};
+
+const toBlob = (canvas: HTMLCanvasElement): Promise<Blob> =>
+  new Promise((resolve, reject) => {
+    canvas.toBlob((blob) => {
+      if (!blob) {
+        reject(new Error('Unable to create sprite sheet image.'));
+        return;
+      }
+      resolve(blob);
+    }, 'image/png');
+  });
+
+const drawFrame = async (
+  context: CanvasRenderingContext2D,
+  frame: FrameAsset,
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  fitMode: FitMode
+) => {
+  const bitmap = await createImageBitmap(frame.file);
+  try {
+    if (fitMode === 'stretch') {
+      context.drawImage(bitmap, x, y, width, height);
+      return;
+    }
+    const { dx, dy, dw, dh } = computeFit(bitmap.width, bitmap.height, width, height, fitMode);
+    context.drawImage(bitmap, x + dx, y + dy, dw, dh);
+  } finally {
+    if (typeof bitmap.close === 'function') {
+      bitmap.close();
+    }
+  }
+};
+
+export const createSpriteSheet = async (
+  frames: FrameAsset[],
+  template: SpriteTemplate
+): Promise<Blob> => {
+  if (!frames.length) {
+    throw new Error('Add frames to your timeline before creating a sprite sheet.');
+  }
+
+  const { width, height, capacity } = computeSpriteSheetSize(template);
+
+  if (!capacity) {
+    throw new Error('Template must define at least one cell.');
+  }
+
+  if (frames.length > capacity) {
+    const overflow = frames.length - capacity;
+    throw new Error(
+      `Template can only fit ${capacity} frame${capacity === 1 ? '' : 's'}. Remove ${overflow} frame${
+        overflow === 1 ? '' : 's'
+      } or choose a larger template.`
+    );
+  }
+
+  const canvas = document.createElement('canvas');
+  canvas.width = width;
+  canvas.height = height;
+  const context = canvas.getContext('2d');
+  if (!context) {
+    throw new Error('Canvas rendering is not supported in this browser.');
+  }
+
+  if (template.background && template.background !== 'transparent') {
+    context.fillStyle = template.background;
+    context.fillRect(0, 0, canvas.width, canvas.height);
+  } else {
+    context.clearRect(0, 0, canvas.width, canvas.height);
+  }
+
+  const cellWidth = template.frameWidth;
+  const cellHeight = template.frameHeight;
+  const spacing = template.spacing;
+  const margin = template.margin;
+
+  for (let index = 0; index < frames.length; index += 1) {
+    const column = index % template.columns;
+    const row = Math.floor(index / template.columns);
+    const x = margin + column * (cellWidth + spacing);
+    const y = margin + row * (cellHeight + spacing);
+    await drawFrame(context, frames[index], x, y, cellWidth, cellHeight, template.fitMode);
+  }
+
+  return toBlob(canvas);
+};

--- a/src/styles.css
+++ b/src/styles.css
@@ -613,6 +613,81 @@ button:disabled {
   gap: 12px;
 }
 
+.sprite-export {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.sprite-template-upload {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.sprite-template-upload input {
+  display: block;
+  width: 100%;
+  padding: 10px 12px;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.6);
+  color: inherit;
+}
+
+.sprite-template-summary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 12px;
+  margin: 0;
+}
+
+.sprite-template-summary div {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.sprite-template-summary dt {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: rgba(148, 163, 184, 0.75);
+}
+
+.sprite-template-summary dd {
+  margin: 0;
+  font-weight: 600;
+  color: #f8fafc;
+}
+
+.sprite-template-note {
+  margin: 0;
+  color: rgba(203, 213, 225, 0.78);
+}
+
+.sprite-template-note.is-error {
+  color: #fda4af;
+  font-weight: 600;
+}
+
+.sprite-template-placeholder {
+  margin: 0;
+  color: rgba(203, 213, 225, 0.7);
+}
+
+.sprite-template-actions {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.sprite-template-error {
+  margin: 0;
+  color: #fda4af;
+  font-weight: 600;
+}
+
 button.ghost {
   background: rgba(15, 23, 42, 0.6);
   border: 1px solid rgba(148, 163, 184, 0.35);


### PR DESCRIPTION
## Summary
- add helpers to parse sprite templates and render sprite sheet images
- add a Sprite Sheet export panel that accepts a JSON template and builds the sheet
- add dedicated styles and tests covering the sprite template utilities

## Testing
- npm run lint
- npm run typecheck
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d0be2c4ed0832e927629bc9b7fe87c