### PR TITLE
Auto-load sample sprite sheet and add drag-and-drop import

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -376,6 +376,12 @@ button:disabled {
   cursor: pointer;
 }
 
+.sheet-file.is-dragging {
+  border-color: rgba(59, 130, 246, 0.75);
+  background: rgba(37, 99, 235, 0.14);
+}
+
+.sheet-file.is-disabled,
 .sheet-file[aria-disabled='true'] {
   opacity: 0.6;
   cursor: not-allowed;


### PR DESCRIPTION
## Summary
- auto-generate and load a basic sample sprite sheet when the importer opens
- add drag-and-drop support and file-type validation for sprite sheet uploads
- style the importer dropzone to reflect drag state

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_b_68d0c1ac5b48832e931e3fb9c07d0f47