### PR TITLE
Add auto character sheet detection

### DIFF
--- a/src/lib/character-sheet.test.ts
+++ b/src/lib/character-sheet.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+
+import { inferCharacterSheetLayout } from './character-sheet';
+
+describe('inferCharacterSheetLayout', () => {
+  it('detects a 3x4 RPG Maker style sheet', () => {
+    const layout = inferCharacterSheetLayout(192, 256);
+    expect(layout).toEqual(
+      expect.objectContaining({
+        columns: 3,
+        rows: 4,
+        frameWidth: 64,
+        frameHeight: 64,
+      }),
+    );
+  });
+
+  it('detects a 4x4 square grid', () => {
+    const layout = inferCharacterSheetLayout(256, 256);
+    expect(layout).toEqual(
+      expect.objectContaining({
+        columns: 4,
+        rows: 4,
+        frameWidth: 64,
+        frameHeight: 64,
+      }),
+    );
+  });
+
+  it('prefers wider walk cycles when ratios match', () => {
+    const layout = inferCharacterSheetLayout(384, 256);
+    expect(layout).toEqual(
+      expect.objectContaining({
+        columns: 6,
+        rows: 4,
+        frameWidth: 64,
+        frameHeight: 64,
+      }),
+    );
+  });
+
+  it('falls back to the best evenly divisible grid', () => {
+    const layout = inferCharacterSheetLayout(150, 200);
+    expect(layout).not.toBeNull();
+    expect(layout?.columns).toBeGreaterThan(1);
+    expect(layout?.rows).toBeGreaterThan(1);
+    expect((layout?.columns ?? 0) * (layout?.frameWidth ?? 0)).toBe(150);
+    expect((layout?.rows ?? 0) * (layout?.frameHeight ?? 0)).toBe(200);
+  });
+
+  it('returns null for invalid dimensions', () => {
+    expect(inferCharacterSheetLayout(-10, 0)).toBeNull();
+  });
+});

--- a/src/lib/character-sheet.ts
+++ b/src/lib/character-sheet.ts
@@ -1,0 +1,192 @@
+import type { FrameAsset } from '../types';
+import { createId } from './id';
+
+export interface CharacterSheetLayout {
+  frameWidth: number;
+  frameHeight: number;
+  columns: number;
+  rows: number;
+  totalFrames: number;
+  score: number;
+  label: string;
+}
+
+interface CandidateLayout {
+  columns: number;
+  rows: number;
+  frameWidth: number;
+  frameHeight: number;
+  score: number;
+  label: string;
+}
+
+const PREFERRED_LAYOUTS: Array<{ columns: number; rows: number; label: string }> = [
+  { columns: 3, rows: 4, label: 'RPG Maker (3×4)' },
+  { columns: 4, rows: 4, label: 'Square grid (4×4)' },
+  { columns: 6, rows: 4, label: 'Wide walk cycle (6×4)' },
+  { columns: 4, rows: 2, label: 'Side scroller (4×2)' },
+  { columns: 8, rows: 4, label: 'Large atlas (8×4)' },
+];
+
+const MAX_GRID_SIZE = 12;
+
+const computeScore = (columns: number, rows: number, frameWidth: number, frameHeight: number) => {
+  const totalFrames = columns * rows;
+  const aspect = frameWidth / frameHeight;
+  const aspectPenalty = Math.abs(Math.log(aspect));
+  let score = aspectPenalty;
+
+  if (totalFrames < 4) {
+    score += (4 - totalFrames) * 0.85;
+  }
+
+  if (totalFrames > 64) {
+    score += (totalFrames - 64) / 24;
+  }
+
+  if (frameWidth < 8 || frameHeight < 8) {
+    score += 1;
+  }
+
+  return score;
+};
+
+export const inferCharacterSheetLayout = (
+  width: number,
+  height: number,
+): CharacterSheetLayout | null => {
+  if (!Number.isFinite(width) || !Number.isFinite(height) || width <= 0 || height <= 0) {
+    return null;
+  }
+
+  const candidates: CandidateLayout[] = [];
+
+  for (const preferred of PREFERRED_LAYOUTS) {
+    if (width % preferred.columns === 0 && height % preferred.rows === 0) {
+      const frameWidth = width / preferred.columns;
+      const frameHeight = height / preferred.rows;
+      const score = computeScore(preferred.columns, preferred.rows, frameWidth, frameHeight) - 0.6;
+      candidates.push({
+        columns: preferred.columns,
+        rows: preferred.rows,
+        frameWidth,
+        frameHeight,
+        score,
+        label: preferred.label,
+      });
+    }
+  }
+
+  for (let columns = 1; columns <= MAX_GRID_SIZE; columns += 1) {
+    if (width % columns !== 0) {
+      continue;
+    }
+    for (let rows = 1; rows <= MAX_GRID_SIZE; rows += 1) {
+      if (height % rows !== 0) {
+        continue;
+      }
+
+      const frameWidth = width / columns;
+      const frameHeight = height / rows;
+
+      const existing = candidates.find(
+        (candidate) => candidate.columns === columns && candidate.rows === rows,
+      );
+      if (existing) {
+        continue;
+      }
+
+      const score = computeScore(columns, rows, frameWidth, frameHeight);
+      candidates.push({
+        columns,
+        rows,
+        frameWidth,
+        frameHeight,
+        score,
+        label: `${columns}×${rows} grid`,
+      });
+    }
+  }
+
+  if (!candidates.length) {
+    return null;
+  }
+
+  candidates.sort((a, b) => a.score - b.score);
+  const best = candidates[0];
+
+  return {
+    frameWidth: best.frameWidth,
+    frameHeight: best.frameHeight,
+    columns: best.columns,
+    rows: best.rows,
+    totalFrames: best.columns * best.rows,
+    score: best.score,
+    label: best.label,
+  };
+};
+
+export const sliceCharacterSheet = async (
+  image: HTMLImageElement,
+  file: File,
+  layout: CharacterSheetLayout,
+): Promise<FrameAsset[]> => {
+  const { frameWidth, frameHeight, columns, rows } = layout;
+  const canvas = document.createElement('canvas');
+  canvas.width = frameWidth;
+  canvas.height = frameHeight;
+
+  const context = canvas.getContext('2d');
+  if (!context) {
+    throw new Error('Canvas rendering is not supported in this browser.');
+  }
+
+  const frames: FrameAsset[] = [];
+  const baseName = file.name.replace(/\.[^./]+$/, '') || 'character';
+  const total = columns * rows;
+
+  for (let index = 0; index < total; index += 1) {
+    const column = index % columns;
+    const row = Math.floor(index / columns);
+    const sourceX = column * frameWidth;
+    const sourceY = row * frameHeight;
+
+    context.clearRect(0, 0, frameWidth, frameHeight);
+    context.drawImage(
+      image,
+      sourceX,
+      sourceY,
+      frameWidth,
+      frameHeight,
+      0,
+      0,
+      frameWidth,
+      frameHeight,
+    );
+
+    const blob = await new Promise<Blob>((resolve, reject) => {
+      canvas.toBlob((value) => {
+        if (!value) {
+          reject(new Error('Unable to create frame from character sprite sheet.'));
+          return;
+        }
+        resolve(value);
+      }, 'image/png');
+    });
+
+    const frameFile = new File([blob], `${baseName}-${String(index + 1).padStart(3, '0')}.png`, {
+      type: 'image/png',
+    });
+    const url = URL.createObjectURL(blob);
+    frames.push({
+      id: createId(),
+      name: frameFile.name,
+      url,
+      width: frameWidth,
+      height: frameHeight,
+      file: frameFile,
+    });
+  }
+
+  return frames;
+};

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,6 +1,12 @@
 :root {
   color-scheme: light dark;
-  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  font-family:
+    'Inter',
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    'Segoe UI',
+    sans-serif;
   background-color: #050816;
   color: #e2e8f0;
 }
@@ -12,9 +18,9 @@
 body {
   margin: 0;
   min-height: 100vh;
-  background: radial-gradient(circle at top, rgba(59, 130, 246, 0.18), transparent 55%),
-    radial-gradient(circle at bottom right, rgba(236, 72, 153, 0.14), transparent 55%),
-    #050816;
+  background:
+    radial-gradient(circle at top, rgba(59, 130, 246, 0.18), transparent 55%),
+    radial-gradient(circle at bottom right, rgba(236, 72, 153, 0.14), transparent 55%), #050816;
 }
 
 button,
@@ -194,7 +200,10 @@ button:disabled {
   border-radius: 18px;
   border: 2px dashed rgba(148, 163, 184, 0.35);
   color: rgba(226, 232, 240, 0.85);
-  transition: border 0.25s ease, background 0.25s ease, transform 0.25s ease;
+  transition:
+    border 0.25s ease,
+    background 0.25s ease,
+    transform 0.25s ease;
 }
 
 .uploader input {
@@ -266,7 +275,9 @@ button:disabled {
   border: 1px solid rgba(100, 116, 139, 0.28);
   border-radius: 16px;
   padding: 12px;
-  transition: border 0.2s ease, transform 0.2s ease;
+  transition:
+    border 0.2s ease,
+    transform 0.2s ease;
 }
 
 .timeline-item.is-active {
@@ -439,7 +450,10 @@ button:disabled {
   border: 1px solid rgba(148, 163, 184, 0.25);
   cursor: pointer;
   pointer-events: auto;
-  transition: background 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease;
+  transition:
+    background 0.15s ease,
+    border-color 0.15s ease,
+    box-shadow 0.15s ease;
 }
 
 .sheet-cell:hover {
@@ -517,6 +531,34 @@ button:disabled {
   gap: 8px;
   font-size: 0.85rem;
   color: rgba(203, 213, 225, 0.75);
+}
+
+.sheet-character {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 12px 14px;
+  border-radius: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  background: rgba(15, 23, 42, 0.65);
+}
+
+.sheet-character strong {
+  display: block;
+  font-size: 1rem;
+  color: #f8fafc;
+}
+
+.sheet-character p {
+  margin: 4px 0 0;
+  color: rgba(203, 213, 225, 0.78);
+  font-size: 0.9rem;
+}
+
+.sheet-character .ghost {
+  align-self: center;
+  white-space: nowrap;
 }
 
 .sheet-manual-actions .ghost {
@@ -700,7 +742,9 @@ button.ghost {
   color: #e2e8f0;
   border-radius: 10px;
   padding: 6px 12px;
-  transition: border 0.2s ease, transform 0.2s ease;
+  transition:
+    border 0.2s ease,
+    transform 0.2s ease;
 }
 
 button.ghost:hover:not(:disabled) {


### PR DESCRIPTION
## Summary
- add character sheet layout inference and slicing helpers
- auto-detect character grids inside the sprite sheet importer UI
- style the importer to surface the detected layout to the user

## Testing
- npm run lint
- npm run typecheck
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_b_68d0c398ec00832eb59c68840c55e34c